### PR TITLE
Add the new ARG instruction introduced in Docker 1.9

### DIFF
--- a/grammars/dockerfile.cson
+++ b/grammars/dockerfile.cson
@@ -10,7 +10,7 @@
         'name': 'keyword.control.dockerfile'
   }
   {
-    'match': '^\\s*(ONBUILD\\s+)?(RUN|EXPOSE|ENV|ADD|COPY|VOLUME|USER|WORKDIR|CMD|ENTRYPOINT|LABEL)\\s'
+    'match': '^\\s*(ONBUILD\\s+)?(RUN|EXPOSE|ENV|ARG|ADD|COPY|VOLUME|USER|WORKDIR|CMD|ENTRYPOINT|LABEL)\\s'
     'captures':
       '0':
         'name': 'keyword.control.dockerfile'


### PR DESCRIPTION
Docker 1.9 introduces a new ARG Instruction in the Dockefiles, as documented [here](http://docs.docker.com/engine/reference/builder/#arg)