### PR TITLE
Update grammars to also highlight linebreak backslashes

### DIFF
--- a/grammars/dockerfile.cson
+++ b/grammars/dockerfile.cson
@@ -40,6 +40,12 @@
     ]
   }
   {
+      'match': '(?m)\\\\$'
+      'captures':
+        '0':
+            'name': 'keyword.control.dockerfile'
+  }
+  {
     'match': '^\\s*#.*$'
     'name': 'comment.block.dockerfile'
   }


### PR DESCRIPTION
Hi there. 

This PR simply adds highlighting support for the backslashes on multiline commands. Personally, I find that it makes the Dockerfile just a touch more readable. 

I figured I'd toss this in as a PR for giggles. If you aren't fond of it, feel free to reject. :blush: 

Here's what it looks like: 

![image](https://cloud.githubusercontent.com/assets/5240018/12029921/dbf8d23c-adc3-11e5-9699-f7084b0bab60.png)

Cheers!

Edit: \***backslashes**\* :expressionless: 