### PR TITLE
Add support of "FROM … AS …" syntax

### DIFF
--- a/grammars/dockerfile.cson
+++ b/grammars/dockerfile.cson
@@ -4,7 +4,15 @@
 ]
 'patterns': [
   {
-    'match': '(?i:^\\s*(maintainer|from)\\s.*)',
+    'match': '(?i:^\\s*(from)\\s.*?(.+?\\s(as)\\s.*)?)',
+    'captures':
+      '1':
+        'name': 'keyword.control.dockerfile'
+      '3':
+        'name': 'keyword.control.dockerfile'
+  },
+  {
+    'match': '(?i:^\\s*(maintainer)\\s.*)',
     'captures':
       '1':
         'name': 'keyword.control.dockerfile'


### PR DESCRIPTION
Some people at #RigaDevDays say docker 17.05CE comes [with a new nice feature](https://twitter.com/backendsecret/status/864123883049365505), "multistaged build". 
Actually I don't know what it is about, but look at the screenshot. `AS` word is not highlighted.

<a href="https://cloud.githubusercontent.com/assets/4586392/26072152/3d016dd8-39b3-11e7-9325-f281c50ef5c4.png"><img src="https://cloud.githubusercontent.com/assets/4586392/26072152/3d016dd8-39b3-11e7-9325-f281c50ef5c4.png" width="500" alt="screenshot"></a>

The feature is known as ["naming build stages"](https://docs.docker.com/engine/userguide/eng-image/multistage-build/#name-your-build-stages)

> By default, the stages are not named, and you refer to them by their integer number, starting with 0 for the first `FROM` instruction. However, you can name your stages, by adding an `as <NAME>` to the `FROM` instruction.

Here is my pull request. I define the additional word `AS` after `FROM`, though `MAINTENER` was moved to another pattern definition. Tests:

<img src="https://cloud.githubusercontent.com/assets/4586392/26073809/8b159ec2-39b8-11e7-8dcc-331a22c3e62c.png" width="400" alt="tests"/>

What do you think about this?
