### PR TITLE
Containerfile support

### DIFF
--- a/grammars/dockerfile.cson
+++ b/grammars/dockerfile.cson
@@ -1,6 +1,7 @@
 'name': 'Dockerfile'
 'fileTypes': [
   'Dockerfile'
+  'Containerfile'
 ]
 'patterns': [
   {


### PR DESCRIPTION
Added new file type for other OCI builders such as [podman](https://podman.io) and [buildah](https://buildah.io)

It has no need to add new syntax as the `Containerfile` and `Dockerfile` specs follow the same OCI specification